### PR TITLE
package.json: add express 3.x to fix docular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
+    "express": "3.x",
     "docular": "^0.6.3",
     "loopback-angular": "^1.1.0",
     "optimist": "^0.6.1",


### PR DESCRIPTION
Docular specifies `express: *` as a dependency, though it does not work
with express 4.x versions.

By adding `express: 3.x` to our package.json, npm will use our copy
of express and don't install the latest express version in docular
node_modules.

This patch is a workaround for gitsome/docular#102 and can be reverted once that fix is landed.

Close #7.

/cc @ritch just FYI, I don't think there is anything to review here.
