### PR TITLE
added model naming strategies

### DIFF
--- a/bin/lb-ng
+++ b/bin/lb-ng
@@ -12,8 +12,10 @@ var argv = optimist
     '\n    $0 [options] server/app.js [client/js/lb-services.js]')
   .describe('m', 'The name for generated Angular module.')
   .default('m', 'lbServices')
+  .describe('c', 'Name casing to use for model name ["upperCaseFirst", "pascalCase" or "camelCase"]')
+  .default('c', 'upperCaseFirst')
   .describe('u', 'URL of the REST API end-point')
-  .alias({ u : 'url', m: 'module-name' })
+  .alias({ u : 'url', m: 'module-name', c: 'name-case' })
   .demand(1)
   .argv;
 
@@ -26,9 +28,10 @@ assertLoopBackVersion();
 
 var ngModuleName = argv['module-name'] || 'lbServices';
 var apiUrl = argv['url'] || app.get('restApiRoot') || '/api';
+var ngNameCase = argv['name-case'] || 'upperCaseFirst';
 
-console.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
-var result = generator.services(app, ngModuleName, apiUrl);
+console.error('Generating %j for the API endpoint %j using name case %j', ngModuleName, apiUrl, ngNameCase);
+var result = generator.services(app, ngModuleName, apiUrl, ngNameCase);
 
 if (outputFile) {
   outputFile = path.resolve(outputFile);

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -32,6 +32,8 @@ describe('lb-ng', function() {
           expect(parse.moduleName(script)).to.equal('lbServices');
           // the value "/rest-api-root" is hard-coded in sampleAppJs
           expect(parse.baseUrl(script)).to.equal('/rest-api-root');
+          // the value "upperCaseFirst" is the --name-case default
+          expect(parse.ngNameCase(script)).to.equal('upperCaseFirst');
         });
     });
 
@@ -46,6 +48,13 @@ describe('lb-ng', function() {
     return runLbNg('-u', 'http://foo/bar', sampleAppJs)
       .spread(function(script, stderr) {
         expect(parse.baseUrl(script)).to.equal('http://foo/bar');
+      });
+  });
+
+  it('uses the nameCase from command-line', function() {
+    return runLbNg('-c', 'pascalCase', sampleAppJs)
+      .spread(function(script, stderr) {
+        expect(parse.ngNameCase(script)).to.equal('pascalCase');
       });
   });
 


### PR DESCRIPTION
added the ability to specify the model naming strategy for the loopback services models
there are three options:
"upperCaseFirst" (default / current behaviour): changes customer to Customer, foo_bar to Foo_bar
"pascalCase" : changes customer to Customer, foo_bar to FooBar
"camelCase" : changes customer to customer, foo_bar to fooBar

this option is specified by the -c option on the lb-ng command