### PR TITLE
deps: upgrade docular to 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "docular": "^0.6.3",
+    "docular": "^0.8.0",
     "loopback-sdk-angular": "^1.1.1",
     "optimist": "^0.6.1",
     "semver": "^2.2.1"


### PR DESCRIPTION
One of the deprecation warnings reported in strongloop/strongloop#243
is caused by docular@0.6.6 and this clears it up.

I'm not sure what all the changes caused by this are. The tests all pass, but there's only a small handful of them in the first place.