### PR TITLE
lb-ng support for async booting apps

### DIFF
--- a/bin/lb-ng
+++ b/bin/lb-ng
@@ -24,30 +24,38 @@ console.error('Loading LoopBack app %j', appFile);
 var app = require(appFile);
 assertLoopBackVersion();
 
-var ngModuleName = argv['module-name'] || 'lbServices';
-var apiUrl = argv['url'] || app.get('restApiRoot') || '/api';
-
-console.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
-var result = generator.services(app, ngModuleName, apiUrl);
-
-if (outputFile) {
-  outputFile = path.resolve(outputFile);
-  console.error('Saving the generated services source to %j', outputFile);
-  fs.writeFileSync(outputFile, result);
+if (app.booting) {
+  app.on('booted', runGenerator);
 } else {
-  console.error('Dumping to stdout');
-  process.stdout.write(result);
+  runGenerator();
 }
 
-// The app.js scaffolded by `slc lb project` loads strong-agent module that
-// used to have a bug where it prevented the application from exiting.
-// To work around that issue, we are explicitly exiting here.
-//
-// The exit is deferred to the next tick in order to prevent the Node bug:
-// https://github.com/joyent/node/issues/3584
-process.nextTick(function() {
-  process.exit();
-});
+function runGenerator() {
+  var ngModuleName = argv['module-name'] || 'lbServices';
+  var apiUrl = argv['url'] || app.get('restApiRoot') || '/api';
+
+  console.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
+  var result = generator.services(app, ngModuleName, apiUrl);
+
+  if (outputFile) {
+    outputFile = path.resolve(outputFile);
+    console.error('Saving the generated services source to %j', outputFile);
+    fs.writeFileSync(outputFile, result);
+  } else {
+    console.error('Dumping to stdout');
+    process.stdout.write(result);
+  }
+
+  // The app.js scaffolded by `slc lb project` loads strong-agent module that
+  // used to have a bug where it prevented the application from exiting.
+  // To work around that issue, we are explicitly exiting here.
+  //
+  // The exit is deferred to the next tick in order to prevent the Node bug:
+  // https://github.com/joyent/node/issues/3584
+  process.nextTick(function() {
+    process.exit();
+  });
+}
 
 //--- helpers ---//
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "debug": "^0.8.0",
     "fs.extra": "^1.2.1",
     "jshint": "^2.5.0",
-    "loopback": "^1.7.4",
-    "loopback-datasource-juggler": "^1.3.10",
+    "loopback": "^2.25.0",
+    "loopback-boot": "^2.14.1",
+    "loopback-datasource-juggler": "^2.42.0",
     "mocha": "^1.18.2"
   }
 }

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -1,18 +1,6 @@
 var loopback = require('loopback');
 var app = loopback();
 
-// Listen on an ephemeral port
-app.set('port', 0);
-
-// Setup default datasources for autoAttach()
-app.dataSource('db', { connector: 'memory', defaultForType: 'db' });
-app.dataSource('mail', { connector: 'mail', defaultForType: 'mail' });
-
-// Attach all built-in models
-loopback.autoAttach();
-
-
-// Configure REST API path
 app.set('restApiRoot', '/rest-api-root');
 
 module.exports = app;

--- a/test/fixtures/async-app/app.js
+++ b/test/fixtures/async-app/app.js
@@ -1,0 +1,21 @@
+var loopback = require('loopback');
+var boot = require('loopback-boot');
+
+var app = loopback();
+
+// Listen on an ephemeral port
+app.set('port', 0);
+
+// Setup default datasources for autoAttach()
+app.dataSource('db', { connector: 'memory', defaultForType: 'db' });
+app.dataSource('mail', { connector: 'mail', defaultForType: 'mail' });
+
+// Attach all built-in models
+loopback.autoAttach();
+
+boot(app, __dirname);
+
+// Configure REST API path
+app.set('restApiRoot', '/rest-api-root');
+
+module.exports = app;

--- a/test/fixtures/async-app/app.js
+++ b/test/fixtures/async-app/app.js
@@ -2,20 +2,6 @@ var loopback = require('loopback');
 var boot = require('loopback-boot');
 
 var app = loopback();
-
-// Listen on an ephemeral port
-app.set('port', 0);
-
-// Setup default datasources for autoAttach()
-app.dataSource('db', { connector: 'memory', defaultForType: 'db' });
-app.dataSource('mail', { connector: 'mail', defaultForType: 'mail' });
-
-// Attach all built-in models
-loopback.autoAttach();
-
 boot(app, __dirname);
-
-// Configure REST API path
-app.set('restApiRoot', '/rest-api-root');
 
 module.exports = app;

--- a/test/fixtures/async-app/boot/boot.js
+++ b/test/fixtures/async-app/boot/boot.js
@@ -1,10 +1,10 @@
 var loopback = require('loopback');
 
 module.exports = function (app, done) {
-   setTimeout(function () {
-     var MyModel = loopback.createModel('ASYNCMODEL', {});
-     app.model(MyModel, { public: true, dataSource: 'db' });
+  process.nextTick(function () {
+    var MyModel = loopback.createModel('ASYNCMODEL', {});
+    app.model(MyModel, { public: true });
 
-     done();
-   }, 1500);
+    done();
+  });
 };

--- a/test/fixtures/async-app/boot/boot.js
+++ b/test/fixtures/async-app/boot/boot.js
@@ -1,0 +1,10 @@
+var loopback = require('loopback');
+
+module.exports = function (app, done) {
+   setTimeout(function () {
+     var MyModel = loopback.createModel('ASYNCMODEL', {});
+     app.model(MyModel, { public: true, dataSource: 'db' });
+
+     done();
+   }, 1500);
+};

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -15,25 +15,23 @@ describe('lb-ng', function() {
   beforeEach(resetSandbox);
 
   it('prints help on no arguments', function() {
-    return runLbNg()
-      .then(function() {
-        throw new Error('lb-ng was supposed to fail with non-zero exit code');
-      })
-      .catch(function(err) {
-        expect(err.code, 'exit code').to.equal(1);
-        expect(err.message).to.contain('Usage');
-      });
+    return runLbNg().then(function() {
+      throw new Error('lb-ng was supposed to fail with non-zero exit code');
+    })
+    .catch(function(err) {
+      expect(err.code, 'exit code').to.equal(1);
+      expect(err.message).to.contain('Usage');
+    });
   });
 
   it('generates "lbServices" module with app.restApiRoot url',
     function() {
-      return runLbNg(sampleAppJs)
-        .spread(function(script, stderr) {
-          // the value "lbServices" is the --module-name default
-          expect(parse.moduleName(script)).to.equal('lbServices');
-          // the value "/rest-api-root" is hard-coded in sampleAppJs
-          expect(parse.baseUrl(script)).to.equal('/rest-api-root');
-        });
+      return runLbNg(sampleAppJs).spread(function(script, stderr) {
+        // the value "lbServices" is the --module-name default
+        expect(parse.moduleName(script)).to.equal('lbServices');
+        // the value "/rest-api-root" is hard-coded in sampleAppJs
+        expect(parse.baseUrl(script)).to.equal('/rest-api-root');
+      });
     });
 
   it('uses the module name from command-line', function() {
@@ -61,10 +59,7 @@ describe('lb-ng', function() {
   });
 
   it('supports async booting apps', function() {
-    this.timeout(3000);
-    return runLbNg(sampleAsyncAppJs)
-    .spread(function(script, stderr) {
-      expect(parse.moduleName(script)).to.equal('lbServices');
+    return runLbNg(sampleAsyncAppJs).spread(function(script, stderr) {
       expect(
         script.match(/\nmodule\.factory\(\s+"ASYNCMODEL"/),
         'presence of late-initialized model'

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -9,6 +9,7 @@ var parse = require('loopback-sdk-angular/parse-helper');
 
 describe('lb-ng', function() {
   var sampleAppJs = require.resolve('./fixtures/app.js');
+  var sampleAsyncAppJs = require.resolve('./fixtures/async-app/app.js');
   var SANDBOX = path.resolve(__dirname, 'sandbox');
 
   beforeEach(resetSandbox);
@@ -57,6 +58,18 @@ describe('lb-ng', function() {
         expect(parse.moduleName(script)).to.equal('a-module');
         expect(stdout).to.equal('');
       });
+  });
+
+  it('supports async booting apps', function() {
+    this.timeout(3000);
+    return runLbNg(sampleAsyncAppJs)
+    .spread(function(script, stderr) {
+      expect(parse.moduleName(script)).to.equal('lbServices');
+      expect(
+        script.match(/\nmodule\.factory\(\s+"ASYNCMODEL"/),
+        'presence of late-initialized model'
+      ).to.be.ok();
+    });
   });
 
   //-- Helpers --


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-sdk-angular-cli/issues/32

-----------------------
We recently added a Loopback boot script that is async, by adding the optional 2nd callback parameter. We did this in order to serially execute some async operations that we have taking place during boot.

Once we did this, two things happened,
   1. Our mixins also started loading async.
   2. Our `lb-ng` command no longer generates a correct client lib - it does not wait for the async boot process, so anything that occurs in the async code (including code from our model mixins that initializes relations, etc) does not execute prior to the client lib generating the libraries.
