### PR TITLE
Update test's regex to reflect SDK change

### DIFF
--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -62,7 +62,7 @@ describe('lb-ng', function() {
   it('supports async booting apps', function() {
     return runLbNg(sampleAsyncAppJs).spread(function(script, stderr) {
       expect(
-        script.match(/\nmodule\.factory\(\s+"ASYNCMODEL"/),
+        script.match(/[\n\s]*module\.factory\([\s\n]*"ASYNCMODEL"/),
         'presence of late-initialized model'
       ).to.be.ok();
     });


### PR DESCRIPTION
Changes on https://github.com/strongloop/loopback-sdk-angular/pull/217 broke the test case

trying to make the test case less syntax dependent 