### PR TITLE
added '-s' flag to pass the includeSchema option to loopback-sdk-angular

### DIFF
--- a/bin/lb-ng
+++ b/bin/lb-ng
@@ -38,7 +38,11 @@ function runGenerator() {
   var includeSchema = argv['include-schema'] || false;
 
   console.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
-  var result = generator.services(app, {ngModuleName: ngModuleName, apiUrl: apiUrl, includeSchema: includeSchema});
+  var result = generator.services(app, {
+    ngModuleName: ngModuleName,
+    apiUrl: apiUrl,
+    includeSchema: includeSchema
+  });
 
   if (outputFile) {
     outputFile = path.resolve(outputFile);

--- a/bin/lb-ng
+++ b/bin/lb-ng
@@ -13,7 +13,9 @@ var argv = optimist
   .describe('m', 'The name for generated Angular module.')
   .default('m', 'lbServices')
   .describe('u', 'URL of the REST API end-point')
-  .alias({ u : 'url', m: 'module-name' })
+  .describe('s', 'Include schema definition in generated models')
+  .boolean('s')
+  .alias({ u : 'url', m: 'module-name', s: 'include-schema' })
   .demand(1)
   .argv;
 
@@ -33,9 +35,10 @@ if (app.booting) {
 function runGenerator() {
   var ngModuleName = argv['module-name'] || 'lbServices';
   var apiUrl = argv['url'] || app.get('restApiRoot') || '/api';
+  var includeSchema = argv['include-schema'] || false;
 
   console.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
-  var result = generator.services(app, ngModuleName, apiUrl);
+  var result = generator.services(app, {ngModuleName: ngModuleName, apiUrl: apiUrl, includeSchema: includeSchema});
 
   if (outputFile) {
     outputFile = path.resolve(outputFile);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "loopback-sdk-angular": "strongloop/loopback-sdk-angular",
+    "loopback-sdk-angular": "^1.8.0",
     "optimist": "^0.6.1",
     "semver": "^2.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "loopback-sdk-angular": "^1.1.1",
+    "loopback-sdk-angular": "strongloop/loopback-sdk-angular",
     "optimist": "^0.6.1",
     "semver": "^2.2.1"
   },

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -8,4 +8,34 @@ var app = loopback();
 
 app.set('restApiRoot', '/rest-api-root');
 
+// this is a hack to give the angular SDK a model to export
+// TODO: create and inject a model the "proper" way
+var TestClass = {
+    name: 'TestClass',
+    sharedClass: {
+        ctor: {
+            settings: {
+                description: 'Test Class',
+            },
+        },
+    },
+    ctor: {
+        getFullPath: function() {}
+    },
+    methods: [],
+
+};
+
+app.models.TestClass = {
+    definition: {
+        properties: {
+            name: 'string',
+        },
+    },
+};
+
+app.handler('rest').adapter.getClasses = function() {
+    return [TestClass];
+};
+
 module.exports = app;

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -8,10 +8,18 @@ var app = loopback();
 
 app.set('restApiRoot', '/rest-api-root');
 
+app.dataSource('db', { connector: 'memory' });
+var TestModel = app.registry.createModel(
+    'TestModel',
+    { foobaz: 'string' }
+);
+app.model(TestModel, { dataSource: 'db' });
+
 // this is a hack to give the angular SDK a model to export
-// TODO: create and inject a model the "proper" way
+// TODO: find out why the model created above is not
+//       returned by the rest adapter
 var TestClass = {
-    name: 'TestClass',
+    name: 'TestModel',
     sharedClass: {
         ctor: {
             settings: {
@@ -23,15 +31,6 @@ var TestClass = {
         getFullPath: function() {}
     },
     methods: [],
-
-};
-
-app.models.TestClass = {
-    definition: {
-        properties: {
-            name: 'string',
-        },
-    },
 };
 
 app.handler('rest').adapter.getClasses = function() {

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -54,6 +54,14 @@ describe('lb-ng', function() {
       });
   });
 
+  it('passes the include-schema flag from the command-line', function() {
+    return runLbNg('-s', sampleAppJs)
+      .spread(function(script, stderr) {
+        expect(script).to.contain('R\.schema =');
+        expect(script).to.contain('schema of the model');
+      });
+  });
+
   it('saves the script to a file', function() {
     var outfile = path.resolve(SANDBOX, 'lb-services.js');
     return runLbNg('-m', 'a-module', sampleAppJs, outfile)


### PR DESCRIPTION
I noticed that an option 'includeSchema' was recently added to [loopback-sdk-angular](https://github.com/strongloop/loopback-sdk-angular) and I needed this feature in lb-ng. I added a new flag '-s' that passes this option.

However, I had some issues while implementing this:
- I needed to require master version of loopback-sdk-angular: [package.json] (https://github.com/janhapke/loopback-sdk-angular-cli/blob/feature/include-schema/package.json#L34)
- I didn't know how to properly 'inject' models into loopback for testing purposes, so I hacked something together that works but doesn't feel right: [test/fixtures/app.js] (https://github.com/janhapke/loopback-sdk-angular-cli/blob/feature/include-schema/test/fixtures/app.js#L11)

I still hope the pull request is useful and maybe somebody can point out a solution for the proper way to inject testing models.