### PR TITLE
Fix process.stdout exiting before done

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
+    "bluebird": "^1.2.4",
     "loopback-sdk-angular": "^1.1.1",
     "optimist": "^0.6.1",
     "semver": "^2.2.1",

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -6,6 +6,13 @@
 var loopback = require('loopback');
 var app = loopback();
 
+// model creation is added so output has enough content to reproduce
+// issue where node v6 to chunk output of child_process and
+// nextTick exit before finish writing (see PR #45)
+app.dataSource('db', { connector: 'memory' });
+var User = loopback.createModel('User');
+app.model(User, { dataSource: 'db' });
+
 app.set('restApiRoot', '/rest-api-root');
 
 module.exports = app;

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -73,6 +73,13 @@ describe('lb-ng', function() {
     });
   });
 
+  it('does not truncate the output', function() {
+    return runLbNg(sampleAppJs)
+      .spread(function(script, stderr) {
+        expect(script).to.match(/\}\)\(window, window.angular\);/);
+      });
+  });
+
   //-- Helpers --
 
   function runLbNg() {


### PR DESCRIPTION
In Node v6 process.nextTick exit causes long messages from stdout.write
to exit before the data is finished writing, looks like only happens in child_process.



@bajtos PTAL
cc/ @0candy 