### PR TITLE
Globalize loopback-angular-sdk-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.swo
 node_modules
 /test/sandbox
+intl/*
+!intl/en/

--- a/bin/lb-ng.js
+++ b/bin/lb-ng.js
@@ -1,18 +1,23 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
 var path = require('path');
+var SG = require('strong-globalize');
+SG.SetRootDir(path.resolve(__dirname, '..'));
+var g = SG();
+var fs = require('fs');
 var semver = require('semver');
 var optimist = require('optimist');
 var generator = require('loopback-sdk-angular');
 
 var argv = optimist
-  .usage('Generate Angular $resource services for your LoopBack application.' +
+  .usage(g.f(
+    'Generate {{Angular $resource}} services ' +
+    'for your {{LoopBack}} application.' +
     '\nUsage:' +
-    '\n    $0 [options] server/app.js [client/js/lb-services.js]')
-  .describe('m', 'The name for generated Angular module.')
+    '\n    $0 {{[options] server/app.js [client/js/lb-services.js]}}'))
+  .describe('m', g.f('The name for generated {{Angular}} module.'))
   .default('m', 'lbServices')
-  .describe('u', 'URL of the REST API end-point')
+  .describe('u', g.f('URL of the REST API end-point'))
   .alias({ u : 'url', m: 'module-name' })
   .demand(1)
   .argv;
@@ -20,7 +25,7 @@ var argv = optimist
 var appFile = path.resolve(argv._[0]);
 var outputFile = argv._[1];
 
-console.error('Loading LoopBack app %j', appFile);
+g.error('Loading {{LoopBack}} app %j', appFile);
 var app = require(appFile);
 assertLoopBackVersion();
 
@@ -34,15 +39,15 @@ function runGenerator() {
   var ngModuleName = argv['module-name'] || 'lbServices';
   var apiUrl = argv['url'] || app.get('restApiRoot') || '/api';
 
-  console.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
+  g.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
   var result = generator.services(app, ngModuleName, apiUrl);
 
   if (outputFile) {
     outputFile = path.resolve(outputFile);
-    console.error('Saving the generated services source to %j', outputFile);
+    g.error('Saving the generated services source to %j', outputFile);
     fs.writeFileSync(outputFile, result);
   } else {
-    console.error('Dumping to stdout');
+    g.error('Dumping to {{stdout}}');
     process.stdout.write(result);
   }
 
@@ -67,10 +72,10 @@ function assertLoopBackVersion() {
   var loopback = Module._load('loopback', Module._cache[appFile]);
 
   if (semver.lt(loopback.version, '1.6.0')) {
-    console.error(
-      '\nThe code generator does not support applications based\n' +
-        'on LoopBack versions older than 1.6.0. Please upgrade your\n' +
-        'project to a recent version of LoopBack and run this tool again.\n');
+    g.error('\n' +
+      'The code generator does not support applications based on\n' +
+      '{{LoopBack}} versions older than 1.6.0. Please upgrade your project\n' +
+      'to a recent version of {{LoopBack}} and run this tool again.\n');
     process.exit(1);
   }
 }

--- a/intl/en/messages.json
+++ b/intl/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "03bb755ed8213986b1862be937b296bb": "The name for generated {{Angular}} module.",
+  "25eecfaa310e55ace4ef6eba593ba32e": "Generating {0} for the API endpoint {1}",
+  "3669f5dd8a727a4f4247d7ad86993e0c": "\nThe code generator does not support applications based on\n{{LoopBack}} versions older than 1.6.0. Please upgrade your project\nto a recent version of {{LoopBack}} and run this tool again.\n",
+  "af39e85bbd74a37c9a8beec4268564bd": "Generate {{Angular $resource}} services for your {{LoopBack}} application.\nUsage:\n    $0 {{[options] server/app.js [client/js/lb-services.js]}}",
+  "dbef1e1c2cc9f52ae9aacca33e9d92c2": "Saving the generated services source to {0}",
+  "dff77762368d4e45c34a01e661ad2c06": "Loading {{LoopBack}} app {0}",
+  "efc6bce92bcb061e3e354a888c7bd76a": "Dumping to {{stdout}}",
+  "fc1c9755ca71e88d7aaa4be225d07bc8": "URL of the REST API end-point"
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "CLI tools for auto-generating Angular $resource services for LoopBack",
   "bin": {
-    "lb-ng": "bin/lb-ng"
+    "lb-ng": "bin/lb-ng.js"
   },
   "scripts": {
     "pretest": "jshint .",
@@ -33,7 +33,8 @@
   "dependencies": {
     "loopback-sdk-angular": "^1.1.1",
     "optimist": "^0.6.1",
-    "semver": "^2.2.1"
+    "semver": "^2.2.1",
+    "strong-globalize": "^2.6.0"
   },
   "devDependencies": {
     "bluebird": "^1.2.1",


### PR DESCRIPTION
@bajtos stl-globalize uses file extensions to determine what gets globalized, I have updated the name to `lb-ng.js`(from `lb-ng`), is there any particular advantage or reasons we shouldn't change it? I can see it being more likely to be skipped by lint as well. 

@0candy PTAL

/cc @Setogit

related to https://github.com/strongloop/loopback/issues/2422