### PR TITLE
child_process to not inherit parent process's env-vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "bluebird": "^1.2.1",
     "chai": "^1.9.1",
-    "debug": "^0.8.0",
+    "debug": "^2.2.0",
     "fs.extra": "^1.2.1",
     "jshint": "^2.5.0",
     "loopback": "^2.25.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "pretest": "jshint .",
-    "test": "mocha"
+    "test": "mocha --timeout 5000"
   },
   "repository": {
     "type": "git",

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -83,12 +83,15 @@ describe('lb-ng', function() {
   //-- Helpers --
 
   function runLbNg() {
+    // empty object for env so it does not inherit env-vars from parent process
+    // this avoids debug messages affecting the stdout
+    var options = {env:{}};
     var argv = [process.execPath, require.resolve('../bin/lb-ng')]
                 .concat(Array.prototype.slice.call(arguments))
                 .map(JSON.stringify)
                 .join(' ');
     debug('--EXECFILE[%s]--', argv);
-    return exec(argv)
+    return exec(argv, options)
       .then(function(args) {
         debug('--STDOUT--\n%s\n--STDERR--\n%s\n--END--', args[0], args[1]);
         return args;


### PR DESCRIPTION
Connect to #49 

>~~Is there any reason we need to enforce *stdout* is empty, maybe we can detect the parts of the script is not there?~~

Changing approach to:
- child_process to not inherit parent process's env-vars
- change to debug@2.2.0
https://github.com/strongloop/loopback-sdk-angular-cli/issues/49#issuecomment-239816855
- increasing timeout on mocha because cis-jenkins machines are often timing out

PTAL @0candy 

cc/ @bajtos 