### PR TITLE
Add flags for namespacing config

### DIFF
--- a/bin/lb-ng.js
+++ b/bin/lb-ng.js
@@ -19,9 +19,14 @@ var argv = optimist
   .describe('m', g.f('The name for generated {{Angular}} module.'))
   .default('m', 'lbServices')
   .describe('u', g.f('URL of the REST API end-point'))
+  .describe('c', g.f('boolean to namespace the common models.'))
+  .boolean('c')
+  .describe('d', g.f('namespace delimiter.'))
+  .default('d', '.')
   .describe('s', 'Include schema definition in generated models')
   .boolean('s')
-  .alias({u: 'url', m: 'module-name', s: 'include-schema'})
+  .alias({u: 'url', m: 'module-name', s: 'include-schema',
+    c: 'namespace-common-models', d: 'namespace-delimiter'})
   .demand(1)
   .argv;
 
@@ -42,11 +47,14 @@ function runGenerator() {
   var ngModuleName = argv['module-name'] || 'lbServices';
   var apiUrl = argv['url'] || app.get('restApiRoot') || '/api';
   var includeSchema = argv['include-schema'] || false;
-
+  var namespaceDelimiter = argv['namespace-delimiter'] || '.';
+  var namespaceCommonModels = argv['namespace-common-models'] || false;
   g.error('Generating %j for the API endpoint %j', ngModuleName, apiUrl);
   var result = generator.services(app, {
     ngModuleName: ngModuleName,
     apiUrl: apiUrl,
+    namespaceCommonModels: namespaceCommonModels,
+    namespaceDelimiter: namespaceDelimiter,
     includeSchema: includeSchema,
   });
 

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -48,6 +48,13 @@ describe('lb-ng', function() {
       });
   });
 
+  it('uses the namespacing common modules from command-line', function() {
+    return runLbNg('-c', 'true', '-d', '_', sampleAppJs)
+      .spread(function(script, stderr) {
+        expect(script).to.match(/lbServices_Resource/);
+      });
+  });
+
   it('uses the url from command-line', function() {
     return runLbNg('-u', 'http://foo/bar', sampleAppJs)
       .spread(function(script, stderr) {


### PR DESCRIPTION
Add a suffix to the core loopback models to allow multiple lb services to exist on the same client, pointing to APIs on different services.

The core models start with 'LoopBack'. The suffix is appended to the LoopBack part of the name while still appending its class after the suffix.

For example if the suffix is Accounts, then the generated core loopback models are: LoopBackAccountsResource, LoopBackAccountsAuth, LoopBackAccountsResourceProvider, LoopBackAccountsAuthRequestInterceptor.
See Issue [issue 250 on loopback-sdk-angular](https://github.com/strongloop/loopback-sdk-angular/issues/250)