### PR TITLE
Revert "Fix process.stdout exiting before done"

### DIFF
--- a/bin/lb-ng.js
+++ b/bin/lb-ng.js
@@ -6,7 +6,6 @@ var SG = require('strong-globalize');
 SG.SetRootDir(path.resolve(__dirname, '..'));
 var g = SG();
 var fs = require('fs');
-var Promise = require('bluebird');
 var semver = require('semver');
 var optimist = require('optimist');
 var generator = require('loopback-sdk-angular');
@@ -60,17 +59,9 @@ function runGenerator() {
     process.stdout.write(result);
   }
 
-  // The app.js scaffolded by `slc lb project` loads strong-agent module that
-  // used to have a bug where it prevented the application from exiting.
-  // To work around that issue, we are explicitly exiting here.
-  //
-  // The exit is deferred to both stdout and err is drained
-  // in order to prevent the Node bug:
+  // The exit is deferred to the next tick in order to prevent the Node bug:
   // https://github.com/joyent/node/issues/3584
-  Promise.all([
-    waitForEvent(process.stdout, 'drain'),
-    waitForEvent(process.stderr, 'drain'),
-  ]).then(function() {
+  process.nextTick(function() {
     process.exit();
   });
 }
@@ -91,11 +82,4 @@ function assertLoopBackVersion() {
       'to a recent version of {{LoopBack}} and run this tool again.\n');
     process.exit(1);
   }
-}
-
-function waitForEvent(obj, name) {
-  return new Promise(function(resolve, reject) {
-    obj.once(name, resolve);
-    obj.once('error', reject);
-  });
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "bluebird": "^1.2.4",
     "loopback-sdk-angular": "^1.8.0",
     "optimist": "^0.6.1",
     "semver": "^2.2.1",

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -7,16 +7,9 @@
 var loopback = require('loopback');
 var app = loopback();
 
-// model creation is added so output has enough content to reproduce
-// issue where node v6 to chunk output of child_process and
-// nextTick exit before finish writing (see PR #45)
 app.dataSource('db', {connector: 'memory'});
-var User = loopback.createModel('User');
-app.model(User, {dataSource: 'db'});
-
 app.set('restApiRoot', '/rest-api-root');
 
-app.dataSource('db', {connector: 'memory'});
 var TestModel = app.registry.createModel(
     'TestModel',
     {foobaz: 'string'}

--- a/test/lb-ng.test.js
+++ b/test/lb-ng.test.js
@@ -56,10 +56,12 @@ describe('lb-ng', function() {
   });
 
   it('passes the include-schema flag from the command-line', function() {
-    return runLbNg('-s', sampleAppJs)
-      .spread(function(script, stderr) {
-        expect(script).to.contain('R\.schema =');
-        expect(script).to.contain('schema of the model');
+    var outfile = path.resolve(SANDBOX, 'lb-services.js');
+    return runLbNg('-s', sampleAppJs, outfile)
+      .spread(function() {
+        var script = fs.readFileSync(outfile);
+        expect(script).to.match(/R\.schema =/);
+        expect(script).to.match(/schema of the model/);
       });
   });
 
@@ -80,13 +82,6 @@ describe('lb-ng', function() {
         'presence of late-initialized model'
       ).to.be.ok();
     });
-  });
-
-  it('does not truncate the output', function() {
-    return runLbNg(sampleAppJs)
-      .spread(function(script, stderr) {
-        expect(script).to.match(/\}\)\(window, window.angular\);/);
-      });
   });
 
   //-- Helpers --


### PR DESCRIPTION
connect to #59 #57

This reverts commit 6a8c379bfc562e8715d3a63288cec29c74116940.
Reverting this fix because many has experienced lb-ng fails to exit and the original fix was only to help stdout getting cut offdue to stdout splits long-text into chunks and process.nextTick
will exit before finish outputing the long-text. Also changing
include-schema test to a file instead of stdout